### PR TITLE
Take to account velocity when closing SideView with pan gesture

### DIFF
--- a/Sources/SideNavigationViewController.swift
+++ b/Sources/SideNavigationViewController.swift
@@ -639,11 +639,15 @@ public class SideNavigationViewController: UIViewController, UIGestureRecognizer
 					
 					delegate?.sideNavigationViewPanDidEnd?(self, point: point, position: .Right)
 					
-					if v.x >= rightViewThreshold {
-						closeRightView(x)
-					} else {
-						openRightView(x)
-					}
+                    if p.x >= 300.0 {
+                        closeLeftView(x)
+                    } else {
+                        if v.x >= rightViewThreshold {
+                            closeRightView(x)
+                        } else {
+                            openRightView(x)
+                        }
+                    }
 				case .Possible:break
 				}
 			}
@@ -676,11 +680,15 @@ public class SideNavigationViewController: UIViewController, UIGestureRecognizer
 					
 					delegate?.sideNavigationViewPanDidEnd?(self, point: point, position: .Left)
 					
-					if v.x <= -leftViewWidth + leftViewThreshold {
-						closeLeftView(x)
-					} else {
-						openLeftView(x)
-					}
+                    if p.x <= -300.0 {
+                        closeLeftView(x)
+                    } else {
+                        if v.x <= -leftViewWidth + leftViewThreshold {
+                            closeLeftView(x)
+                        } else {
+                            openLeftView(x)
+                        }
+                    }
 				case .Possible:break
 				}
 			}


### PR DESCRIPTION
When a user want’s to close a side view using pan gesture, It needs to pan a least half of the side view before it can automatically close when user release it’s thumb. Using here the velocity, the user can do a quick movement with the thumb to close the view. It feels much better like this.
